### PR TITLE
.observe() bug fix, unbindAfterIntersect setting added

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Default: `0.1`
 ### options.unbindAfterIntersect
 Type: `Boolean`   
 Determines if the observed element should be unobserved after crossing its observation threshold for the first time.  
-Default: `false`
+Default: `true`
 
 #### options.onIntersectionCallback
 Type: `Function`  

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default: `0.1`
 
 ### options.unbindAfterIntersect
 Type: `Boolean`   
-Determines if the observed element should be unobserved after its crossing its observation threshold for the first time.  
+Determines if the observed element should be unobserved after crossing its observation threshold for the first time.  
 Default: `false`
 
 #### options.onIntersectionCallback

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default: `0.1`
 
 ### options.unbindAfterIntersect
 Type: `Boolean`   
-Determines if the observed element should be unobserved after crossing its observation threshold for the first time.  
+Determines if the observed elements should be unobserved after crossing their respective observation thresholds for the first time.  
 Default: `true`
 
 #### options.onIntersectionCallback

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Returns: `Element`
 An optional callback that will override the default image-loading behavior, and simply return the observed element that has entered the viewport.  
 Default: `null`
 
+#### options.onNonIntersectionCallback
+Type: `Function`  
+Returns: `Element`  
+An optional callback that will return the observed element that has left the viewport.  
+Default: `null`
+
 ## Methods
 
 ### .observe(els)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Type: `Number`
 Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed. From the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options).  
 Default: `0.1`
 
+### options.unbindAfterIntersect
+Type: `Boolean`   
+Determines if the observed element should be unobserved after its crossing its observation threshold for the first time.  
+Default: `false`
+
 #### options.onIntersectionCallback
 Type: `Function`  
 Returns: `Element`  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lazy",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A lazy loader based on the IntersectionObserver API",
     "keywords": [
         "lazy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lazy",
-    "version": "1.2.0",
+    "version": "1.1.0",
     "description": "A lazy loader based on the IntersectionObserver API",
     "keywords": [
         "lazy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lazy",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A lazy loader based on the IntersectionObserver API",
     "keywords": [
         "lazy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lazy",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A lazy loader based on the IntersectionObserver API",
     "keywords": [
         "lazy",

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -7,8 +7,10 @@ const lazy = (options = {}) => {
         rootMargin: '200px 0px',
         threshold: 0.1,
         unbindAfterIntersect: true,
-        onIntersectionCallback: null
+        onIntersectionCallback: null,
+        onNonIntersectionCallback: null
     };
+    let initialIntersection = true;
     let observer = null;
     let settings;
     let els;
@@ -30,11 +32,21 @@ const lazy = (options = {}) => {
 
     const onIntersection = entries => {
         entries.forEach(entry => {
-            if (entry.intersectionRatio > 0) {
-                const el = entry.target;
+            const el = entry.target;
+            if (entry.isIntersecting) {
                 load(el);
+            } else {
+                onNonIntersection(el);
             }
         });
+    };
+
+    const onNonIntersection = el => {
+        if (settings.onNonIntersectionCallback !== null && 
+            initialIntersection === false) {
+            settings.onNonIntersectionCallback(el);
+        }
+        initialIntersection = false;
     };
 
     const observe = (els = null) => {

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -60,20 +60,20 @@ const lazy = (options = {}) => {
         if (els) {
             const elsArr = ensureArray(els);
             elsArr.forEach(el => {
-                if (settings.unbindAfterIntersect === true) {
-                    unbindObserver(el);
-                }
-                if (settings.onIntersectionCallback !== null) {
+                unbindObserver(el);
+                if (settings.onIntersectionCallback !== null && 
+                    initialIntersection === false) {
                     settings.onIntersectionCallback(el);
                 } else {
                     setElAttrs(el);
                 }
             });
+            initialIntersection = false;
         }
     };
 
     const unbindObserver = el => {
-        if (observer) {
+        if (observer && settings.unbindAfterIntersect === true) {
             observer.unobserve(el);
         }
     };

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -6,6 +6,7 @@ const lazy = (options = {}) => {
         root: null,
         rootMargin: '200px 0px',
         threshold: 0.1,
+        unbindAfterIntersect: true,
         onIntersectionCallback: null
     };
     let observer = null;
@@ -15,9 +16,7 @@ const lazy = (options = {}) => {
     const init = () => {
         settings = {...defaults, ...options};
         els = [...document.querySelectorAll(`${settings.elSelector}`)];
-        if (els.length > 0) {
-            intersectionObserverIsSupported() ? bindObserver(els) : load(els);
-        }
+        intersectionObserverIsSupported() ? bindObserver(els) : load(els);
     };
 
     const bindObserver = els => {
@@ -38,7 +37,7 @@ const lazy = (options = {}) => {
         });
     };
 
-    const observe = els => {
+    const observe = (els = null) => {
         if (els && observer !== null) {
             const elsArr = ensureArray(els);
             elsArr.forEach(el => observer.observe(el));
@@ -49,7 +48,9 @@ const lazy = (options = {}) => {
         if (els) {
             const elsArr = ensureArray(els);
             elsArr.forEach(el => {
-                unbindObserver(el);
+                if (settings.unbindAfterIntersect === true) {
+                    unbindObserver(el);
+                }
                 if (settings.onIntersectionCallback !== null) {
                     settings.onIntersectionCallback(el);
                 } else {

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -1,87 +1,105 @@
-import {capitalize} from '../../../utils/stringUtils.js';
-import {getNextButtonAction} from '../../../utils/renderUtils.js';
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
-import {changeEligibility} from '../../actions/formActions.js';
-import Description from './description.js';
-import Field from './field.js';
-import ActionButtons from './actionButtons.js';
+const lazy = (options = {}) => {
 
-const nextButtonActionConfig = {
-    conditionalVals: [
-        'military',
-        'spouse',
-        'child'
-    ],
-    conditionalDestination: 'eligibilityDetails',
-    defaultDestination: 'policyHolder'
+    const defaults = {
+        elSelector: '[data-lazy]',
+        animationClass: null,
+        root: null,
+        rootMargin: '200px 0px',
+        threshold: 0.1,
+        unbindAfterIntersect: true,
+        onIntersectionCallback: null,
+        onNonIntersectionCallback: null
+    };
+    let initialIntersection = true;
+    let observer = null;
+    let settings;
+    let els;
+
+    const init = () => {
+        settings = {...defaults, ...options};
+        els = [...document.querySelectorAll(`${settings.elSelector}`)];
+        intersectionObserverIsSupported() ? bindObserver(els) : load(els);
+    };
+
+    const bindObserver = els => {
+        observer = new IntersectionObserver(onIntersection, {
+            root: settings.root,
+            rootMargin: settings.rootMargin,
+            threshold: settings.threshold
+        });
+        observe(els);
+    };
+
+    const onIntersection = entries => {
+        entries.forEach(entry => {
+            const el = entry.target;
+            if (entry.isIntersecting) {
+                load(el);
+            } else {
+                onNonIntersection(el);
+            }
+        });
+    };
+
+    const onNonIntersection = el => {
+        if (settings.onNonIntersectionCallback !== null && 
+            initialIntersection === false) {
+            settings.onNonIntersectionCallback(el);
+        }
+        initialIntersection = false;
+    };
+
+    const observe = (els = null) => {
+        if (els && observer !== null) {
+            const elsArr = ensureArray(els);
+            elsArr.forEach(el => observer.observe(el));
+        }
+    };
+
+    const load = els => {
+        if (els) {
+            const elsArr = ensureArray(els);
+            elsArr.forEach(el => {
+                unbindObserver(el);
+                if (settings.onIntersectionCallback !== null) {
+                    settings.onIntersectionCallback(el);
+                } else {
+                    setElAttrs(el);
+                }
+            });
+            initialIntersection = false;
+        }
+    };
+
+    const unbindObserver = el => {
+        if (observer && settings.unbindAfterIntersect === true) {
+            observer.unobserve(el);
+        }
+    };
+
+    const setElAttrs = el => {
+        if (settings.animationClass) {
+            el.classList.add(settings.animationClass);
+        }
+        if (el.dataset.src) {
+            el.src = el.dataset.src;
+        }
+        if (el.dataset.srcset) {
+            el.srcset = el.dataset.srcset;
+        }
+    };
+
+    const ensureArray = maybeArr => Array.isArray(maybeArr) ? maybeArr : [maybeArr];
+    
+    const intersectionObserverIsSupported = () => 'IntersectionObserver' in window;
+
+    init();
+
+    return {
+        observe,
+        load
+    };
+
 };
 
-const mapDispatchToProps = dispatch => ({
-    changeEligibility: payload => dispatch(changeEligibility(payload))
-});
-
-class Eligibility extends Component {
-
-	constructor(props) {
-        super(props);
-        this.handleInputChange = this.handleInputChange.bind(this);
-        this.state = {
-            nextButton: {
-                name: 'next',
-                action: getNextButtonAction(this.props.eligibilityStatus, nextButtonActionConfig)
-            }
-        };
-    }
-
-    componentDidMount() {
-        this.props.changeEligibility(this.props.eligibilityStatus);
-    }
-
-    handleInputChange({name, value}) {
-        this.props.changeEligibility(value);
-        this.setState({
-            nextButton: {
-                ...this.state.nextButton,
-                action: getNextButtonAction(value, nextButtonActionConfig)
-            }
-        });
-        this.props.handleInputChange({
-            name,
-            value
-        });
-    }
-	
-	render() {
-        const {
-            heading, 
-            description,
-            fields
-        } = this.props.section;
-
-        return (
-            <form
-                ref={form => this.formEl = form}
-                onSubmit={e => this.props.handleSubmit(e, this.formEl, this.state.nextButton.action)}
-                noValidate>
-                <div className="wrapper">
-                    <h1>{heading}</h1>
-                    <Description 
-                        description={description} />
-                    <Field 
-                        field={fields.eligibilityStatus}
-                        type='radio'
-                        modifierClass='field--large-radio'
-                        handleInputChange={this.handleInputChange} />
-                </div>
-                <ActionButtons 
-                    handleButtonClick={this.props.handleButtonClick}
-                    buttons={[
-                        this.state.nextButton
-                    ]} />
-            </form>
-        );
-	}
-}
-
-export default connect(null, mapDispatchToProps)(Eligibility);
+export default lazy;


### PR DESCRIPTION
- Fixed an issue that would prevent the .observe(els) method from working if there were no observable elements found during instantiation.
- Added an "unbindAfterIntersect: [bool]" setting. It still defaults to true, but can be overridden now (useful when using the "onIntersectionCallback" setting).